### PR TITLE
Give index.md a valid frontmatter

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Bitcoin Beach
+---
+
 ## Bitcoin Beach
 
 **arentura** helps you find where and what to rent at the Bitcoin Beach in El Zonte!


### PR DESCRIPTION
The index.html/landing page was not building for me locally under Jekyll 4.2.2 (most recent afaik). The [Jekyll docs](https://jekyllrb.com/docs/structure/) state that if the landing page is markdown it also has to have a valid frontmatter. With this PR I can locally build the whole site as described in `developersGuide.md`.